### PR TITLE
ci: Extend timeout for build step on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,13 @@ before_install:
 install:
   # get and clean source
   - clean_code $REPO_DIR $BUILD_COMMIT
-  - build_wheel $REPO_DIR
+  # use travis_wait to bypass 10 minute timeout on osx. Running delocate takes > 10m.
+  - |
+    if [ ${TRAVIS_OS_NAME} = "osx" ]; then
+      travis_wait 60 build_wheel $REPO_DIR
+    else
+      build_wheel $REPO_DIR
+    fi
 
 script:
   - install_run


### PR DESCRIPTION
Running `delocate` can take more than 10 minutes.