### PR TITLE
chore: Bump version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ version: ~> 1.0
 env:
   global:
     - REPO_DIR=httpstan
-    - BUILD_COMMIT=2.0.1
+    - BUILD_COMMIT=2.0.2
     - BUILD_DEPENDS="Cython"
     # test dependencies from the [tool.poetry.dev-dependencies] section in pyproject.toml
-    - TEST_DEPENDS="pytest-cov~=2.8 pytest-asyncio<0.11,>=0.10 pytest-xdist~=1.32 apispec[yaml,validation]~=3.1"
+    - TEST_DEPENDS="pytest-cov~=2.8 pytest-asyncio<0.11,>=0.10 apispec[yaml,validation]~=3.1"
     - MB_ML_VER=2014
     - DOCKER_TEST_IMAGE=multibuild/xenial_x86_64
 
@@ -27,13 +27,11 @@ jobs:
     language: objective-c
     env:
       - MB_PYTHON_VERSION=3.7
-      - PYTEST_ARGS="--forked"
   - os: osx
     osx_image: xcode11.3
     language: objective-c
     env:
       - MB_PYTHON_VERSION=3.8
-      - PYTEST_ARGS="--forked"
 
 before_install:
   - source multibuild/common_utils.sh

--- a/config.sh
+++ b/config.sh
@@ -18,7 +18,7 @@ function run_tests {
     python -c 'import httpstan'
     # empty directory is inside the repo directory (see ``install_run``)
     SRC_DIR=httpstan
-    python -m pytest -s -v $PYTEST_ARGS ../$SRC_DIR/tests
+    python -m pytest -s -v ../$SRC_DIR/tests
 }
 
 function poetry_wheel_cmd {


### PR DESCRIPTION
`pytest-xdist` is no longer a test dependency. Removed it.