### PR TITLE
feat: Build wheels twice a week

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,12 @@
 name: Build and publish wheels
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0,3' # run twice a week
 
 jobs:
   build:


### PR DESCRIPTION
Build wheels twice a week. This change
means that wheels for new versions
of httpstan will be built automatically.
No pull request will be required in this repo.

Note: This assumes the default branch has been renamed to `main`.