### PR TITLE
ci: Add Python 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-20.04, macos-10.14]
         platform: [x64]
 


### PR DESCRIPTION
Numpy 3.10 wheels have been released for macOS.