### PR TITLE
ci: Use newer macOS only for Python 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,10 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-20.04, macos-11.0]
+        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-20.04, macos-10.15]
         platform: [x64]
-
+        include:
+          - python-version: "3.10"
+            os: ubuntu-20.04
+            platform: x64
+          - python-version: "3.10"
+            os: macos-11.0
+            platform: x64
     env:
       REPO_DIR: httpstan
       # BUILD_COMMIT is set in a step below to the most recent tagged version


### PR DESCRIPTION
A newer version is not needed for older versions and creates
less compatible wheels.