### PR TITLE
fix: Drop support for Python 3.7 per NEP 29

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, macos-10.15]
         platform: [x64]
         include:


### PR DESCRIPTION
Following NumPy's NEP 29,
https://numpy.org/neps/nep-0029-deprecation_policy.html