### PR TITLE
ci: build macos aarch64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-20.04, macos-10.15]
         platform: [x64]
         include:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,9 @@ jobs:
           - python-version: "3.10"
             os: macos-11.0
             platform: x64
+          - python-version: "3.10"
+            os: macos-11.0
+            platform: arm64
     env:
       REPO_DIR: httpstan
       # BUILD_COMMIT is set in a step below to the most recent tagged version


### PR DESCRIPTION
Trying out what I see in https://github.com/python-pillow/pillow-wheels

Attempt at cross-compiling an arm wheel for macos.