### PR TITLE
ci(macos): Set MB_PYTHON_OSX_VER to 10.9

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,16 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
-        os: [ubuntu-20.04, macos-11]
+        python-version: [3.8, 3.9, "3.10"]
+        os: [ubuntu-20.04, macos-latest]
         platform: [x64]
-        include:
-          - python-version: "3.10"
-            os: ubuntu-20.04
-            platform: x64
-          - python-version: "3.10"
-            os: macos-11
-            platform: x64
     env:
       REPO_DIR: httpstan
       # BUILD_COMMIT is set in a step below to the most recent tagged version
@@ -60,8 +53,7 @@ jobs:
           pip install virtualenv
       - name: Set multibuild environment variables
         run: |
-          if [ "macos-latest" == "${{ matrix.os }}" ]; then echo "TRAVIS_OS_NAME=osx" >> $GITHUB_ENV; else echo "TRAVIS_OS_NAME=${{ matrix.os }}" >> $GITHUB_ENV; fi
-          if [ "arm64" == "${{ matrix.platform }}" ]; then echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV; echo "PLAT=arm64" >> $GITHUB_ENV; else echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> $GITHUB_ENV; fi
+          if [ "macos-latest" == "${{ matrix.os }}" ]; then echo "MB_PYTHON_OSX_VER=10.9" >> $GITHUB_ENV; fi
       - name: Use most recent tag as BUILD_COMMIT
         run: echo "BUILD_COMMIT=$(cd httpstan && git tag --sort version:refname | tail -1)" >> $GITHUB_ENV
       - name: Print environment variables
@@ -72,7 +64,7 @@ jobs:
           echo "TRAVIS_EVENT_TYPE: ${TRAVIS_EVENT_TYPE}"
           echo "TRAVIS_OS_NAME: ${TRAVIS_OS_NAME}"
           echo "PLAT: ${PLAT}"
-          echo "MACOSX_DEPLOYMENT_TARGET: ${MACOSX_DEPLOYMENT_TARGET}"
+          echo "MB_PYTHON_OSX_VER: ${MB_PYTHON_OSX_VER}"
           echo "DOCKER_TEST_IMAGE: ${DOCKER_TEST_IMAGE}"
           echo "BUILD_DEPENDS: ${BUILD_DEPENDS}"
           echo "TEST_DEPENDS: ${TEST_DEPENDS}"

--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ GitHub Actions tries to release previously-unreleased versions of `httpstan` twi
 ### Differences from the standard ``multibuild`` instructions
 
 - `BUILD_COMMIT` is automatically set to the most recent tagged version of `httpstan`. See `.github/workflows/wheels.yml`.
-- ``MACOSX_DEPLOYMENT_TARGET`` is currently set to ``10.9``. Multibuild gives the variable
-  a different default value. This environment variable is set in `.github/workflows/wheels.yml`.
+- `MB_PYTHON_OSX_VER=10.9` is set in `.github/workflows/wheels.yml`.


### PR DESCRIPTION
Possible fix to current macos PyPI downloading issues. Follows current multibuild instructions.

Note that `MACOSX_DEPLOYMENT_TARGET` is no longer used anywhere in multibuild.