### PR TITLE
ci: Use macos-latest image

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10"]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
         platform: [x64]
     env:
       REPO_DIR: httpstan
@@ -53,9 +53,9 @@ jobs:
           pip install virtualenv
       - name: Set multibuild environment variables
         run: |
-          if [ "macos-10.15" == "${{ matrix.os }}" ]; then echo "PLAT=x86_64" >> $GITHUB_ENV; fi
-          if [ "macos-10.15" == "${{ matrix.os }}" ]; then echo "ARCHFLAGS=-arch x86_64" >> $GITHUB_ENV; fi
-          if [ "macos-10.15" == "${{ matrix.os }}" ]; then echo "MB_PYTHON_OSX_VER=10.9" >> $GITHUB_ENV; fi
+          if [ "macos-latest" == "${{ matrix.os }}" ]; then echo "PLAT=x86_64" >> $GITHUB_ENV; fi
+          if [ "macos-latest" == "${{ matrix.os }}" ]; then echo "ARCHFLAGS=-arch x86_64" >> $GITHUB_ENV; fi
+          if [ "macos-latest" == "${{ matrix.os }}" ]; then echo "MB_PYTHON_OSX_VER=10.9" >> $GITHUB_ENV; fi
       - name: Use most recent tag as BUILD_COMMIT
         run: echo "BUILD_COMMIT=$(cd httpstan && git tag --sort version:refname | tail -1)" >> $GITHUB_ENV
       - name: Print environment variables


### PR DESCRIPTION
Now that ARCHFLAGS is set, macos-11 should work fine.

Github states that 10.15 is deprecated, hence this change.
